### PR TITLE
Don't call DebugSetProcessKillOnExit if SafeAttach is enabled

### DIFF
--- a/TitanEngine/TitanEngine.Debugger.cpp
+++ b/TitanEngine/TitanEngine.Debugger.cpp
@@ -554,14 +554,11 @@ __declspec(dllexport) bool TITCALL AttachDebugger(DWORD ProcessId, bool KillOnEx
         {
             if(engineEnableDebugPrivilege)
                 EngineSetDebugPrivilege(GetCurrentProcess(), false);
-            if(KillOnExit)
+            funcDebugSetProcessKillOnExit = GetProcAddress(GetModuleHandleA("kernel32.dll"), "DebugSetProcessKillOnExit");
+            if(funcDebugSetProcessKillOnExit != NULL)
             {
-                funcDebugSetProcessKillOnExit = GetProcAddress(GetModuleHandleA("kernel32.dll"), "DebugSetProcessKillOnExit");
-                if(funcDebugSetProcessKillOnExit != NULL)
-                {
-                    myDebugSetProcessKillOnExit = (fDebugSetProcessKillOnExit)(funcDebugSetProcessKillOnExit);
-                    myDebugSetProcessKillOnExit(KillOnExit);
-                }
+                myDebugSetProcessKillOnExit = (fDebugSetProcessKillOnExit)(funcDebugSetProcessKillOnExit);
+                myDebugSetProcessKillOnExit(KillOnExit && !engineSafeAttach ? true : false);
             }
             DebugDebuggingDLL = false;
             DebugAttachedToProcess = true;


### PR DESCRIPTION
Related to https://github.com/x64dbg/x64dbg/issues/2411. If `SafeAttach` is enabled or `KillOnExit` is false, call `DebugSetProcessKillOnExit` with `false`. Otherwise call it with `true`.

This seems to stop lsass from dying when detaching on Windows 10. "Normal" debugger exit behaviour is preserved, i.e. if the debugger is closed then so is any running debuggee.