### PR TITLE
SetBPX: check return value of VirtualProtectEx before writing

### DIFF
--- a/TitanEngine/TitanEngine.Breakpoints.cpp
+++ b/TitanEngine/TitanEngine.Breakpoints.cpp
@@ -246,7 +246,8 @@ __declspec(dllexport) bool TITCALL SetBPX(ULONG_PTR bpxAddress, DWORD bpxType, L
     }
     //set breakpoint in process
     bpxDataCmpPtr = (PMEMORY_COMPARE_HANDLER)bpxDataPrt;
-    VirtualProtectEx(dbgProcessInformation.hProcess, (LPVOID)bpxAddress, NewBreakPoint.BreakPointSize, PAGE_EXECUTE_READWRITE, &OldProtect);
+    if(!VirtualProtectEx(dbgProcessInformation.hProcess, (LPVOID)bpxAddress, NewBreakPoint.BreakPointSize, PAGE_EXECUTE_READWRITE, &OldProtect))
+        return false;
     if(ReadProcessMemory(dbgProcessInformation.hProcess, (LPVOID)bpxAddress, &NewBreakPoint.OriginalByte[0], NewBreakPoint.BreakPointSize, &NumberOfBytesReadWritten))
     {
         if(WriteProcessMemory(dbgProcessInformation.hProcess, (LPVOID)bpxAddress, bpxDataPrt, NewBreakPoint.BreakPointSize, &NumberOfBytesReadWritten))


### PR DESCRIPTION
`SetBPX` was not checking the return value of the first call to `VirtualProtectEx` before attempting to write the breakpoint to memory. If `VirtualProtectEx` fails, `OldProtect` may be set to `PAGE_NOACCESS`, which on the second call to `VirtualProtectEx` will cause a previously X/RX/RWX region to be set to no access, which obviously causes an instant access violation and kills the debuggee.

With this PR the breakpoint will still fail to be set, but it won't kill the process.

Reported by @JustasMasiulis.