### PR TITLE
Fix 'MemoryReadSafe' not restoring original memory protection correctly

### DIFF
--- a/TitanEngine/Global.Engine.Threading.h
+++ b/TitanEngine/Global.Engine.Threading.h
@@ -10,6 +10,7 @@
 enum CriticalSectionLock
 {
     LockBreakPointBuffer,
+    LockMemoryProtection,
     LockLast
 };
 


### PR DESCRIPTION
Run this script:

```
alloc 5000;
addr = $res;

memset addr,90,5000;
setpagerights addr+3000, "GExecuteReadWrite";
cip = addr+2ff0;
getpagerights addr+3000;

sti
sti

getpagerights addr+3000;
```


The expected output should be something like this (because we didn't touch the page):
```
Page: 018E3000, Rights: ERW-G  
Page: 018E3000, Rights: ERW-G
```
But it's actually this:
```
Page: 018E3000, Rights: ERW-G  
Page: 018E3000, Rights: ERW--
```

The reason for this behavior is that before single stepping, the debugger reads the next 16 bytes to check if the following instruction is `pushfd` or `push ss`. To do this, it calls the `MemoryReadSafe` function, which initially tries to use `ReadProcessMemory` and fails because there is a guarded page. Then it sets a more permissible page protection (PAGE_EXECUTE_READ) on the whole range. After the job is done, it will try to restore the original protection from the initial call to `VirtualProtectEx`. The problem is that if the original page contains several different types of protection (like one page is `PAGE_READWRITE` and another is `PAGE_READWRITE | PAGE_GUARD`), it'll simply overwrite the whole page range with the first page protection (e.g. `PAGE_READWRITE`).
The solution is to save and restore each page individually.

GleeBug doesn't have this problem because it just fails to read memory entirely, without changing memory protection