### PR TITLE
Fix conditional breakpoints being triggered unconditionally during stepping and hijacking the step

### DIFF
--- a/TitanEngine/Global.Debugger.cpp
+++ b/TitanEngine/Global.Debugger.cpp
@@ -31,7 +31,7 @@ std::vector<ULONG_PTR> tlsCallBackList;
 std::vector<PROCESS_ITEM_DATA> hListProcess;
 DWORD engineStepCount = 0;
 LPVOID engineStepCallBack = NULL;
-bool engineStepActive = false;
+DWORD engineStepTID = 0;
 bool engineProcessIsNowDetached = false;
 DWORD DBGCode = DBG_CONTINUE;
 bool engineFileIsBeingDebugged = false;

--- a/TitanEngine/Global.Debugger.h
+++ b/TitanEngine/Global.Debugger.h
@@ -31,7 +31,7 @@ extern std::vector<ULONG_PTR> tlsCallBackList;
 extern std::vector<PROCESS_ITEM_DATA> hListProcess;
 extern DWORD engineStepCount;
 extern LPVOID engineStepCallBack;
-extern bool engineStepActive;
+extern DWORD engineStepTID;
 extern bool engineProcessIsNowDetached;
 extern DWORD DBGCode;
 extern bool engineFileIsBeingDebugged;

--- a/TitanEngine/TitanEngine.Debugger.Control.cpp
+++ b/TitanEngine/TitanEngine.Debugger.Control.cpp
@@ -38,7 +38,7 @@ __declspec(dllexport) void TITCALL ForceClose()
 __declspec(dllexport) void TITCALL StepInto(LPVOID StepCallBack)
 {
     EnterCriticalSection(&engineStepActiveCr);
-    if (!engineStepActive)
+    if (engineStepTID == 0)
     {
         ULONG_PTR ueCurrentPosition = GetContextData(UE_CIP);
         unsigned char instr[16];
@@ -60,7 +60,7 @@ __declspec(dllexport) void TITCALL StepInto(LPVOID StepCallBack)
             myDBGContext.EFlags |= UE_TRAP_FLAG;
             SetThreadContext(hActiveThread, &myDBGContext);
             EngineCloseHandle(hActiveThread);
-            engineStepActive = true;
+            engineStepTID = DBGEvent.dwThreadId;
             engineStepCallBack = StepCallBack;
             engineStepCount = 0;
         }

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -16,14 +16,14 @@
 static void engineStep()
 {
     EnterCriticalSection(&engineStepActiveCr);
-    if (engineStepActive)
+    if (engineStepTID == DBGEvent.dwThreadId)
     {
         DBGCode = DBG_CONTINUE;
         if (engineStepCount == 0)
         {
             typedef void(TITCALL* fCustomBreakPoint)(void);
             auto cbStep = fCustomBreakPoint(engineStepCallBack);
-            engineStepActive = false;
+            engineStepTID = 0;
             engineStepCallBack = NULL;
             LeaveCriticalSection(&engineStepActiveCr);
             cbStep();
@@ -1237,7 +1237,7 @@ __declspec(dllexport) void TITCALL DebugLoop()
             //general unhandled exception callback
             if(DBGCode == DBG_EXCEPTION_NOT_HANDLED)
             {
-                engineStepActive = false;
+                engineStepTID = 0;
 
                 if(DBGCustomHandler->chUnhandledException != NULL)
                 {


### PR DESCRIPTION
This should fix #20.

The fix is pretty straightforward but there's still room for improvement:
- Conditional breakpoints with a false condition will still trigger if they happen to occur on the same thread. I'll try to fix this too but it seems a bit more complicated. We'd need to have TitanEngine able to check the breakpoint condition (e.g. through a callback into x64) and decide whether to skip based on that.
- We still can't step from multiple different threads at the same time (Visual Studio allows this), as only one stepping thread ID will be saved. This could be circumvented by storing a vector of thread IDs awaiting a step, rather than a single TID, but I'm not sure if it's worth it?