### PR TITLE
Fix thread suspension when hardware breakpoint is disabled during callback

### DIFF
--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -724,6 +724,7 @@ __declspec(dllexport) void TITCALL DebugLoop()
                                 GetThreadContext(hActiveThread, &myDBGContext);
                                 myDBGContext.EFlags &= ~UE_TRAP_FLAG;
                                 SetThreadContext(hActiveThread, &myDBGContext);
+                                synchronizedStep = false;
                             }
                         }
                         else
@@ -755,6 +756,7 @@ __declspec(dllexport) void TITCALL DebugLoop()
                                 GetThreadContext(hActiveThread, &myDBGContext);
                                 myDBGContext.EFlags &= ~UE_TRAP_FLAG;
                                 SetThreadContext(hActiveThread, &myDBGContext);
+                                synchronizedStep = false;
                             }
                         }
                         else
@@ -786,6 +788,7 @@ __declspec(dllexport) void TITCALL DebugLoop()
                                 GetThreadContext(hActiveThread, &myDBGContext);
                                 myDBGContext.EFlags &= ~UE_TRAP_FLAG;
                                 SetThreadContext(hActiveThread, &myDBGContext);
+                                synchronizedStep = false;
                             }
                         }
                         else
@@ -817,6 +820,7 @@ __declspec(dllexport) void TITCALL DebugLoop()
                                 GetThreadContext(hActiveThread, &myDBGContext);
                                 myDBGContext.EFlags &= ~UE_TRAP_FLAG;
                                 SetThreadContext(hActiveThread, &myDBGContext);
+                                synchronizedStep = false;
                             }
                         }
                         else


### PR DESCRIPTION
Other threads remained permanently suspended after hitting a HWBP, disabling it, and pressing Run.

This PR fixes this. The issue being that when a HWBP is disabled in the callback, the trap flag is cleared but `synchronizedStep` is not set to false, which caused other threads to be suspended (as it was still true) but the single-step event never fired to resume them. Simply setting it to false when clearing the trap flag for the disabled HWBP fixes this issue.