### PR TITLE
Fix multi-thread breakpoint deletion race condition

### DIFF
--- a/TitanEngine/Global.Breakpoints.cpp
+++ b/TitanEngine/Global.Breakpoints.cpp
@@ -4,6 +4,7 @@
 
 std::vector<BreakPointDetail> BreakPointBuffer;
 std::unordered_map<ULONG_PTR, MemoryBreakpointPageDetail> MemoryBreakpointPages;
+std::unordered_set<ULONG_PTR> recentlyDeletedBpx;
 
 ULONG_PTR dr7uint(DR7* dr7)
 {

--- a/TitanEngine/Global.Breakpoints.h
+++ b/TitanEngine/Global.Breakpoints.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "Global.Engine.Threading.h"
 #include "Global.Engine.h"
@@ -11,6 +12,7 @@
 
 extern std::vector<BreakPointDetail> BreakPointBuffer;
 extern std::unordered_map<ULONG_PTR, MemoryBreakpointPageDetail> MemoryBreakpointPages;
+extern std::unordered_set<ULONG_PTR> recentlyDeletedBpx;
 
 void uintdr7(ULONG_PTR dr7, DR7* ret);
 ULONG_PTR dr7uint(DR7* dr7);

--- a/TitanEngine/Global.Debugger.cpp
+++ b/TitanEngine/Global.Debugger.cpp
@@ -89,6 +89,7 @@ void DebuggerReset()
     }
     std::vector<BreakPointDetail>().swap(BreakPointBuffer);
     std::unordered_map<ULONG_PTR, MemoryBreakpointPageDetail>().swap(MemoryBreakpointPages);
+    recentlyDeletedBpx.clear();
 }
 
 void ClearProcessList()

--- a/TitanEngine/TitanEngine.Breakpoints.cpp
+++ b/TitanEngine/TitanEngine.Breakpoints.cpp
@@ -303,6 +303,7 @@ __declspec(dllexport) bool TITCALL DeleteBPX(ULONG_PTR bpxAddress)
     FlushInstructionCache(dbgProcessInformation.hProcess, NULL, 0);
     VirtualProtectEx(dbgProcessInformation.hProcess, (LPVOID)bpxAddress, BreakPointBuffer.at(found).BreakPointSize, OldProtect, &OldProtect);
     BreakPointBuffer.erase(BreakPointBuffer.begin() + found);
+    recentlyDeletedBpx.insert(bpxAddress);
     return true;
 }
 

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -589,11 +589,36 @@ __declspec(dllexport) void TITCALL DebugLoop()
                 {
                     if(DebugAttachedToProcess || !FirstBPX) //program generated a breakpoint exception
                     {
-                        DBGCode = DBG_EXCEPTION_NOT_HANDLED;
-                        if(DBGCustomHandler->chBreakPoint != NULL)
+                        ULONG_PTR exceptionAddress = (ULONG_PTR)DBGEvent.u.Exception.ExceptionRecord.ExceptionAddress;
+                        unsigned char currentByte = 0xCC;
+                        MemoryReadSafe(dbgProcessInformation.hProcess, (void*)exceptionAddress, &currentByte, 1, nullptr);
+
+                        if(currentByte != 0xCC)
                         {
-                            myCustomHandler = (fCustomHandler)((LPVOID)DBGCustomHandler->chBreakPoint);
-                            myCustomHandler(&DBGEvent.u.Exception.ExceptionRecord);
+                            //breakpoint was deleted - the byte is no longer 0xCC
+                            //reset IP to exception address and continue gracefully
+                            DBGCode = DBG_CONTINUE;
+                            hActiveThread = EngineOpenThread(THREAD_GETSETSUSPEND, false, DBGEvent.dwThreadId);
+                            CONTEXT myDBGContext;
+                            myDBGContext.ContextFlags = ContextControlFlags;
+                            GetThreadContext(hActiveThread, &myDBGContext);
+#if defined(_WIN64)
+                            myDBGContext.Rip = exceptionAddress;
+#else
+                            myDBGContext.Eip = (DWORD)exceptionAddress;
+#endif
+                            SetThreadContext(hActiveThread, &myDBGContext);
+                            EngineCloseHandle(hActiveThread);
+                        }
+                        else
+                        {
+                            //byte is still 0xCC - this is a real int3 in the original code!!
+                            DBGCode = DBG_EXCEPTION_NOT_HANDLED;
+                            if(DBGCustomHandler->chBreakPoint != NULL)
+                            {
+                                myCustomHandler = (fCustomHandler)((LPVOID)DBGCustomHandler->chBreakPoint);
+                                myCustomHandler(&DBGEvent.u.Exception.ExceptionRecord);
+                            }
                         }
                     }
                     else //system breakpoint

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -101,6 +101,8 @@ __declspec(dllexport) void TITCALL DebugLoop()
     memset(&DLLDebugFileName, 0, sizeof(DLLDebugFileName));
     engineFileIsBeingDebugged = true;
 
+    uint32_t consecutiveTimeouts = 0;
+
     while(!BreakDBG) //actual debug loop
     {
         bool synchronizedStep = false;
@@ -124,9 +126,16 @@ __declspec(dllexport) void TITCALL DebugLoop()
             else
             {
                 // Regular timeout, wait again
+                // After 2 consecutive timeouts, clear recently deleted breakpoints
+                consecutiveTimeouts++;
+                if(consecutiveTimeouts >= 2)
+                    recentlyDeletedBpx.clear();
                 continue;
             }
         }
+
+        // Event received, reset timeout counter
+        consecutiveTimeouts = 0;
 
         if(IsDbgReplyLaterSupported)
         {
@@ -590,29 +599,29 @@ __declspec(dllexport) void TITCALL DebugLoop()
                     if(DebugAttachedToProcess || !FirstBPX) //program generated a breakpoint exception
                     {
                         ULONG_PTR exceptionAddress = (ULONG_PTR)DBGEvent.u.Exception.ExceptionRecord.ExceptionAddress;
-                        unsigned char currentByte = 0xCC;
-                        MemoryReadSafe(dbgProcessInformation.hProcess, (void*)exceptionAddress, &currentByte, 1, nullptr);
 
-                        if(currentByte != 0xCC)
+                        if(recentlyDeletedBpx.find(exceptionAddress) != recentlyDeletedBpx.end())
                         {
-                            //breakpoint was deleted - the byte is no longer 0xCC
-                            //reset IP to exception address and continue gracefully
-                            DBGCode = DBG_CONTINUE;
+                            //breakpoint was recently deleted - handle the stale event gracefully
                             hActiveThread = EngineOpenThread(THREAD_GETSETSUSPEND, false, DBGEvent.dwThreadId);
-                            CONTEXT myDBGContext;
-                            myDBGContext.ContextFlags = ContextControlFlags;
-                            GetThreadContext(hActiveThread, &myDBGContext);
+                            if(hActiveThread != NULL)
+                            {
+                                CONTEXT myDBGContext;
+                                myDBGContext.ContextFlags = ContextControlFlags;
+                                GetThreadContext(hActiveThread, &myDBGContext);
 #if defined(_WIN64)
-                            myDBGContext.Rip = exceptionAddress;
+                                myDBGContext.Rip = exceptionAddress;
 #else
-                            myDBGContext.Eip = (DWORD)exceptionAddress;
+                                myDBGContext.Eip = (DWORD)exceptionAddress;
 #endif
-                            SetThreadContext(hActiveThread, &myDBGContext);
-                            EngineCloseHandle(hActiveThread);
+                                SetThreadContext(hActiveThread, &myDBGContext);
+                                EngineCloseHandle(hActiveThread);
+                                DBGCode = DBG_CONTINUE;
+                            }
                         }
                         else
                         {
-                            //byte is still 0xCC - this is a real int3 in the original code!!
+                            //not a recently deleted breakpoint - pass to debuggee
                             DBGCode = DBG_EXCEPTION_NOT_HANDLED;
                             if(DBGCustomHandler->chBreakPoint != NULL)
                             {


### PR DESCRIPTION
This PR fixes a software breakpoint bug that can cause crashes in multi-threaded debugging. Similar to https://github.com/x64dbg/GleeBug/pull/76



