### PR TITLE
fix: ensure write-only breakpoints trigger on Copy-on-Write pages

### DIFF
--- a/TitanEngine/Global.Breakpoints.cpp
+++ b/TitanEngine/Global.Breakpoints.cpp
@@ -251,13 +251,17 @@ DWORD GetPageProtectionForMemoryBreakpoint(const MemoryBreakpointPageDetail & pa
 
     if(page.writeBps > 0)
     {
-        // Remove write access e.g. PAGE_EXECUTE_READWRITE => PAGE_EXECUTE
+        // Remove write access (and copy-on-write) e.g. PAGE_EXECUTE_READWRITE => PAGE_EXECUTE
         DWORD dwBase = newProtect & 0xFF;
         switch(dwBase)
         {
         case PAGE_READWRITE:
+        case PAGE_WRITECOPY:
+            newProtect = (newProtect & 0xFFFFFF00) | PAGE_READONLY;
+            break;
         case PAGE_EXECUTE_READWRITE:
-            newProtect = (newProtect & 0xFFFFFF00) | (dwBase >> 1);
+        case PAGE_EXECUTE_WRITECOPY:
+            newProtect = (newProtect & 0xFFFFFF00) | PAGE_EXECUTE_READ;
             break;
         }
     }


### PR DESCRIPTION
This PR fixes a bug where write-only memory breakpoints would silently fail to trigger on pages utilizing Copy-on-Write protections (PAGE_WRITECOPY and PAGE_EXECUTE_WRITECOPY).

The previous implementation relied on an implicit bit-shift (dwBase >> 1) to downgrade page protections. While this successfully converted standard PAGE_READWRITE to PAGE_READONLY, it completely ignored PAGE_WRITECOPY flags.

Because the flags were ignored, the OS would silently handle any write attempts to these pages by duplicating the page in memory (the standard CoW behavior) instead of throwing the expected Access Violation (0xC0000005) needed to trip the breakpoint handler.

The new implementation correctly maps PAGE_READWRITE, PAGE_WRITECOPY into PAGE_READONLY and PAGE_EXECUTE_READWRITE, PAGE_EXECUTE_WRITECOPY into PAGE_EXECUTE_READ.