### PR TITLE
fixes an issue where you cannot step over int3 instructions even with…

### DIFF
--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -600,7 +600,10 @@ __declspec(dllexport) void TITCALL DebugLoop()
                     {
                         ULONG_PTR exceptionAddress = (ULONG_PTR)DBGEvent.u.Exception.ExceptionRecord.ExceptionAddress;
 
-                        if(recentlyDeletedBpx.find(exceptionAddress) != recentlyDeletedBpx.end())
+                        unsigned char currentByte = 0xCC;
+                        MemoryReadSafe(dbgProcessInformation.hProcess, (void*)exceptionAddress, &currentByte, 1, nullptr);
+
+                        if(currentByte != 0xCC && recentlyDeletedBpx.find(exceptionAddress) != recentlyDeletedBpx.end())
                         {
                             //breakpoint was recently deleted - handle the stale event gracefully
                             hActiveThread = EngineOpenThread(THREAD_GETSETSUSPEND, false, DBGEvent.dwThreadId);

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -601,6 +601,10 @@ __declspec(dllexport) void TITCALL DebugLoop()
                         ULONG_PTR exceptionAddress = (ULONG_PTR)DBGEvent.u.Exception.ExceptionRecord.ExceptionAddress;
 
                         if(recentlyDeletedBpx.find(exceptionAddress) != recentlyDeletedBpx.end())
+                        unsigned char currentByte = 0xCC;
+                        MemoryReadSafe(dbgProcessInformation.hProcess, (void*)exceptionAddress, &currentByte, 1, nullptr);
+
+                        if(currentByte != 0xCC && recentlyDeletedBpx.find(exceptionAddress) != recentlyDeletedBpx.end())
                         {
                             //breakpoint was recently deleted - handle the stale event gracefully
                             hActiveThread = EngineOpenThread(THREAD_GETSETSUSPEND, false, DBGEvent.dwThreadId);


### PR DESCRIPTION
fixes #33

1. When stepping, debugger inserts a breakpoint on the next instruction.
2. When that instruction gets hit, it removes it's temporary breakpoint correctly, however if the actual next instruction is a real breakpoint in the asm, the debugger incorrectly says "I just cleaned up at breakpoint at this address" without checking whether it was a real breakpoint byte.
