### PR TITLE
Per-thread stepping state + fix hardware-breakpoint reset race on thread exit

### DIFF
--- a/TitanEngine/Global.Debugger.cpp
+++ b/TitanEngine/Global.Debugger.cpp
@@ -29,9 +29,7 @@ DWORD ProcessExitCode = 0;
 HANDLE DBGFileHandle;
 std::vector<ULONG_PTR> tlsCallBackList;
 std::vector<PROCESS_ITEM_DATA> hListProcess;
-DWORD engineStepCount = 0;
-LPVOID engineStepCallBack = NULL;
-bool engineStepActive = false;
+std::unordered_map<DWORD, EngineStepThreadState> engineStepThreads;
 bool engineProcessIsNowDetached = false;
 DWORD DBGCode = DBG_CONTINUE;
 bool engineFileIsBeingDebugged = false;
@@ -90,6 +88,7 @@ void DebuggerReset()
     std::vector<BreakPointDetail>().swap(BreakPointBuffer);
     std::unordered_map<ULONG_PTR, MemoryBreakpointPageDetail>().swap(MemoryBreakpointPages);
     recentlyDeletedBpx.clear();
+    engineStepThreads.clear();
 }
 
 void ClearProcessList()

--- a/TitanEngine/Global.Debugger.h
+++ b/TitanEngine/Global.Debugger.h
@@ -2,6 +2,7 @@
 #define _GLOBAL_DEBUGGER_H
 
 #include <vector>
+#include <unordered_map>
 #include <Windows.h>
 
 extern HARDWARE_DATA DebugRegister[4];
@@ -29,9 +30,18 @@ extern DWORD ProcessExitCode;
 extern HANDLE DBGFileHandle;
 extern std::vector<ULONG_PTR> tlsCallBackList;
 extern std::vector<PROCESS_ITEM_DATA> hListProcess;
-extern DWORD engineStepCount;
-extern LPVOID engineStepCallBack;
-extern bool engineStepActive;
+// Per-thread pending single-step state. A single-step (user step or the internal
+// step-over of a breakpoint) is always armed on a specific thread by setting that
+// thread's trap flag, but the resulting STATUS_SINGLE_STEP event can be delivered
+// interleaved with other threads' events. Keying the step state by thread id makes
+// each thread consume only its own step, and allows several threads to be stepped
+// independently (matching GleeBug).
+struct EngineStepThreadState
+{
+    LPVOID callback; // step callback to fire when the step completes
+    DWORD count;     // remaining repeats (0 = fire the callback on the next step)
+};
+extern std::unordered_map<DWORD, EngineStepThreadState> engineStepThreads;
 extern bool engineProcessIsNowDetached;
 extern DWORD DBGCode;
 extern bool engineFileIsBeingDebugged;

--- a/TitanEngine/TitanEngine.Debugger.Control.cpp
+++ b/TitanEngine/TitanEngine.Debugger.Control.cpp
@@ -38,7 +38,9 @@ __declspec(dllexport) void TITCALL ForceClose()
 __declspec(dllexport) void TITCALL StepInto(LPVOID StepCallBack)
 {
     EnterCriticalSection(&engineStepActiveCr);
-    if(!engineStepActive)
+    // Arm a single-step for the current event thread only. State is per-thread, so a
+    // step already pending on another thread does not block this one.
+    if(engineStepThreads.find(DBGEvent.dwThreadId) == engineStepThreads.end())
     {
         ULONG_PTR ueCurrentPosition = GetContextData(UE_CIP);
         unsigned char instr[16];
@@ -60,9 +62,7 @@ __declspec(dllexport) void TITCALL StepInto(LPVOID StepCallBack)
             myDBGContext.EFlags |= UE_TRAP_FLAG;
             SetThreadContext(hActiveThread, &myDBGContext);
             EngineCloseHandle(hActiveThread);
-            engineStepActive = true;
-            engineStepCallBack = StepCallBack;
-            engineStepCount = 0;
+            engineStepThreads[DBGEvent.dwThreadId] = { StepCallBack, 0 };
         }
     }
     LeaveCriticalSection(&engineStepActiveCr);
@@ -93,7 +93,11 @@ __declspec(dllexport) void TITCALL StepOut(LPVOID StepOut, bool StepFinal)
 __declspec(dllexport) void TITCALL SingleStep(DWORD StepCount, LPVOID StepCallBack)
 {
     StepInto(StepCallBack);
-    engineStepCount = StepCount - 1; //We already stepped once
+    EnterCriticalSection(&engineStepActiveCr);
+    auto it = engineStepThreads.find(DBGEvent.dwThreadId);
+    if(it != engineStepThreads.end())
+        it->second.count = StepCount - 1; //We already stepped once
+    LeaveCriticalSection(&engineStepActiveCr);
 }
 
 __declspec(dllexport) void TITCALL SetNextDbgContinueStatus(DWORD SetDbgCode)

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -160,20 +160,14 @@ __declspec(dllexport) void TITCALL DebugLoop()
             {
                 if(ThreadBeingProcessed != 0 && DBGEvent.dwThreadId == ThreadBeingProcessed)
                 {
-                    // Resume the other threads since the thread being processed is exiting
-                    for(auto & itr : SuspendedThreads)
-                        ResumeThread(itr.second.hThread);
-
-                    SuspendedThreads.clear();
-                    ThreadBeingProcessed = 0;
-
                     // The thread was in the middle of a breakpoint step-over (its
                     // breakpoint was temporarily removed and a restore was pending on its
                     // next single-step) but it is exiting before that single-step arrives.
-                    // Complete the restore now: otherwise the breakpoint is left removed
-                    // and the next thread's event would consume this dead thread's orphaned
-                    // reset state and be misinterpreted as a step-over reset, producing a
-                    // stray single-step that is passed to (and crashes) the debuggee.
+                    // Complete the restore now, while the other threads are still
+                    // suspended - otherwise the breakpoint is left removed and the next
+                    // thread's event would consume this dead thread's orphaned reset state
+                    // and be misinterpreted as a step-over reset, producing a stray
+                    // single-step that is passed to (and crashes) the debuggee.
                     if(ResetBPX)
                     {
                         EnableBPX(ResetBPXAddressTo);
@@ -182,7 +176,23 @@ __declspec(dllexport) void TITCALL DebugLoop()
                     }
                     if(ResetHwBPX)
                     {
-                        SetHardwareBreakPoint(DebugRegisterX.DrxBreakAddress, DebugRegisterXId, DebugRegisterX.DrxBreakPointType, DebugRegisterX.DrxBreakPointSize, (LPVOID)DebugRegisterX.DrxCallBack);
+                        // Re-enable the stepped-over slot in the authoritative DebugRegister[]
+                        // table (DeleteHardwareBreakPoint cleared it when the breakpoint was
+                        // hit), then re-arm every enabled hardware breakpoint on each still-
+                        // suspended thread from that table - exactly as CREATE_THREAD arms a
+                        // new thread. Rebuilding from DebugRegister[] rather than from the
+                        // exiting thread's (gone) context or a live thread's DR7 (which may
+                        // have been cleared) is what keeps the OTHER hardware breakpoints from
+                        // being disabled. This must run before the threads are resumed:
+                        // SetThreadContext does not reliably update a running thread's debug
+                        // registers.
+                        int drIdx = (DebugRegisterXId == UE_DR0) ? 0 : (DebugRegisterXId == UE_DR1) ? 1 : (DebugRegisterXId == UE_DR2) ? 2 : 3;
+                        DebugRegister[drIdx] = DebugRegisterX;
+                        static const DWORD drIds[4] = { UE_DR0, UE_DR1, UE_DR2, UE_DR3 };
+                        for(auto & itr : SuspendedThreads)
+                            for(int s = 0; s < 4; s++)
+                                if(DebugRegister[s].DrxEnabled)
+                                    SetHardwareBreakPointEx(itr.second.hThread, DebugRegister[s].DrxBreakAddress, drIds[s], DebugRegister[s].DrxBreakPointType, DebugRegister[s].DrxBreakPointSize, (LPVOID)DebugRegister[s].DrxCallBack, NULL);
                         ResetHwBPX = false;
                     }
                     if(ResetMemBPX)
@@ -196,6 +206,13 @@ __declspec(dllexport) void TITCALL DebugLoop()
                         ResetMemBPX = false;
                     }
                     PushfBPX = false;
+
+                    // Resume the other threads now that the breakpoint has been restored.
+                    for(auto & itr : SuspendedThreads)
+                        ResumeThread(itr.second.hThread);
+
+                    SuspendedThreads.clear();
+                    ThreadBeingProcessed = 0;
                 }
             }
         }
@@ -380,6 +397,15 @@ __declspec(dllexport) void TITCALL DebugLoop()
                     break;
                 }
             }
+
+            // Drop any per-thread single-step state for the exiting thread. A thread can
+            // exit after StepInto() armed its step but before the trap event is delivered
+            // (e.g. it is terminated externally); without this, a reused thread id would
+            // inherit the stale entry - StepInto() would decline to arm the trap flag, or
+            // a later single-step could fire the dead thread's callback.
+            EnterCriticalSection(&engineStepActiveCr);
+            engineStepThreads.erase(DBGEvent.dwThreadId);
+            LeaveCriticalSection(&engineStepActiveCr);
         }
         break;
 

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -166,6 +166,36 @@ __declspec(dllexport) void TITCALL DebugLoop()
 
                     SuspendedThreads.clear();
                     ThreadBeingProcessed = 0;
+
+                    // The thread was in the middle of a breakpoint step-over (its
+                    // breakpoint was temporarily removed and a restore was pending on its
+                    // next single-step) but it is exiting before that single-step arrives.
+                    // Complete the restore now: otherwise the breakpoint is left removed
+                    // and the next thread's event would consume this dead thread's orphaned
+                    // reset state and be misinterpreted as a step-over reset, producing a
+                    // stray single-step that is passed to (and crashes) the debuggee.
+                    if(ResetBPX)
+                    {
+                        EnableBPX(ResetBPXAddressTo);
+                        ResetBPXAddressTo = 0;
+                        ResetBPX = false;
+                    }
+                    if(ResetHwBPX)
+                    {
+                        SetHardwareBreakPoint(DebugRegisterX.DrxBreakAddress, DebugRegisterXId, DebugRegisterX.DrxBreakPointType, DebugRegisterX.DrxBreakPointSize, (LPVOID)DebugRegisterX.DrxCallBack);
+                        ResetHwBPX = false;
+                    }
+                    if(ResetMemBPX)
+                    {
+                        ResetMemBpxCallback();
+                        if(ResetMemBpxExtraCallback != nullptr)
+                        {
+                            ResetMemBpxExtraCallback();
+                            ResetMemBpxExtraCallback = nullptr;
+                        }
+                        ResetMemBPX = false;
+                    }
+                    PushfBPX = false;
                 }
             }
         }

--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -16,22 +16,28 @@
 static void engineStep()
 {
     EnterCriticalSection(&engineStepActiveCr);
-    if(engineStepActive)
+    // Only deliver the pending single-step to the thread it was armed for. State is
+    // per-thread, so an automatic breakpoint step-over on a different thread cannot
+    // consume this thread's step or fire its callback on the wrong thread.
+    auto it = engineStepThreads.find(DBGEvent.dwThreadId);
+    if(it != engineStepThreads.end())
     {
         DBGCode = DBG_CONTINUE;
-        if(engineStepCount == 0)
+        if(it->second.count == 0)
         {
             typedef void(TITCALL * fCustomBreakPoint)(void);
-            auto cbStep = fCustomBreakPoint(engineStepCallBack);
-            engineStepActive = false;
-            engineStepCallBack = NULL;
+            auto cbStep = fCustomBreakPoint(it->second.callback);
+            engineStepThreads.erase(it);
             LeaveCriticalSection(&engineStepActiveCr);
             cbStep();
         }
         else
         {
-            SingleStep(engineStepCount, engineStepCallBack);
+            auto count = it->second.count;
+            auto callback = it->second.callback;
+            engineStepThreads.erase(it); // SingleStep re-arms this thread's entry
             LeaveCriticalSection(&engineStepActiveCr);
+            SingleStep(count, callback);
         }
     }
     else
@@ -1288,7 +1294,11 @@ __declspec(dllexport) void TITCALL DebugLoop()
             //general unhandled exception callback
             if(DBGCode == DBG_EXCEPTION_NOT_HANDLED)
             {
-                engineStepActive = false;
+                // The current thread's pending single-step (if any) did not complete
+                // normally; cancel it. Other threads' steps are unaffected.
+                EnterCriticalSection(&engineStepActiveCr);
+                engineStepThreads.erase(DBGEvent.dwThreadId);
+                LeaveCriticalSection(&engineStepActiveCr);
 
                 if(DBGCustomHandler->chUnhandledException != NULL)
                 {


### PR DESCRIPTION
Fixes two related multi-thread races in `DebugLoop`, both reproduced deterministically in a headless harness (upstreamed to [DebugLoopRace](https://github.com/mrexodia/DebugLoopRace) as `TestStepRace`). Addresses the cross-thread issues discussed around #20/#21.

## 1. Keep per-thread stepping state (`e80b959`)

The single-step state (`engineStepActive`/`engineStepCount`/`engineStepCallBack`) was **global**, but a step is always armed on a specific thread (its trap flag). When a step is pending on thread A and a *different* thread B runs the automatic breakpoint step-over, B's `STATUS_SINGLE_STEP` consumed the global state and fired A's step callback on the **wrong thread** (spurious pause; corrupted step-over accounting — the "threads stay suspended after disabling a breakpoint" report, and #20's implicit-breakpoint deletion).

Replaced the globals with a per-thread map `std::unordered_map<DWORD, EngineStepThreadState> engineStepThreads` keyed by thread id. Each thread consumes only its own step; several threads can be stepped independently. This matches GleeBug's design and is strictly more general than the single-TID approach in #21 (it also handles simultaneous stepping of multiple threads).

## 2. Complete orphaned breakpoint step-over reset when the stepped thread exits (`ba2a3aa`, `ed4bdd1`)

Separate, pre-existing race, most visible with hardware breakpoints. When a thread is terminated (e.g. `ExitProcess` force-killing threads, or `TerminateThread`) while it is the `ThreadBeingProcessed` mid-step-over — its breakpoint temporarily removed and a restore pending on its next single-step — the `EXIT_THREAD` handler cleared `ThreadBeingProcessed` but left the reset state armed and the breakpoint removed. The next thread's reply-later'd event then consumed that orphaned reset and a following event became a stray single-step (Dr0=0, Dr6=0) passed to the debuggee unhandled → crash/hang under contention.

Fix: when the thread-being-processed exits, complete the pending restore and clear the reset flags. From review feedback (`ed4bdd1`):
- The hardware-breakpoint restore rebuilds each still-**suspended** thread's debug registers from the authoritative `DebugRegister[]` table (re-arming every enabled slot, as the `CREATE_THREAD` path does) rather than from the exiting thread's now-gone context — otherwise DR7 was rebuilt with only the restored slot and any **other** hardware breakpoint was silently disabled. The restore runs before the threads are resumed (`SetThreadContext` does not reliably update a running thread's debug registers).
- The `EXIT_THREAD` handler also erases the exiting thread's per-thread single-step entry, so a reused thread id can't inherit stale step state.

## Testing

`TestStepRace` modes (DebugLoopRace), all passing with this PR:
- `hijack`, `multistep` — cross-thread / simultaneous step hijack (software bp)
- `hwhijack`, `memhijack` — same over hardware / memory breakpoints
- `swstress`, `hwstress`, `memstress` — multi-thread breakpoint contention, no stepping
- `hwexit` — terminates the hitting thread from a hardware-breakpoint callback to force a mid-step-over exit (pre-fix: hangs/crashes)
- `hw2stress`, `hw2exit` — a **second** hardware breakpoint (DR1) alongside `hwexit`; asserts DR1 keeps firing after the DR0 reset-recovery (pre-`ed4bdd1`: DR1 silently disabled)

x64dbg test suite: **46/46 on both TitanEngine and GleeBug**.