### PR TITLE
DebugLoop: continue past a program's DebugBreak()/int 3 like Visual Studio

### DIFF
--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -694,8 +694,22 @@ __declspec(dllexport) void TITCALL DebugLoop()
                         }
                         else
                         {
-                            //not a recently deleted breakpoint - pass to debuggee
-                            DBGCode = DBG_EXCEPTION_NOT_HANDLED;
+                            // A program-generated breakpoint exception not raised by a debugger-set
+                            // breakpoint. Distinguish a real single-byte `int 3` instruction
+                            // (DebugBreak()/__debugbreak(): the byte at ExceptionAddress is 0xCC and
+                            // the CPU already advanced RIP past it) from a programmatic exception
+                            // such as RaiseException(STATUS_BREAKPOINT) (no 0xCC at that address).
+                            //
+                            //  - real int 3: consume it (DBG_CONTINUE) like Visual Studio, so the
+                            //    thread resumes at the instruction after the int 3 and execution
+                            //    continues past the program's own DebugBreak.
+                            //  - otherwise: pass it to the debuggee (DBG_EXCEPTION_NOT_HANDLED) so
+                            //    the program's SEH handlers run (e.g. RaiseException+__except).
+                            unsigned char opcode = 0;
+                            bool isInt3 = MemoryReadSafe(dbgProcessInformation.hProcess,
+                                                         (LPVOID)exceptionAddress, &opcode, 1, 0) &&
+                                          opcode == 0xCC;
+                            DBGCode = isInt3 ? DBG_CONTINUE : DBG_EXCEPTION_NOT_HANDLED;
                             if(DBGCustomHandler->chBreakPoint != NULL)
                             {
                                 myCustomHandler = (fCustomHandler)((LPVOID)DBGCustomHandler->chBreakPoint);


### PR DESCRIPTION
## Summary

A program-generated breakpoint exception — `DebugBreak()`, `__debugbreak()` or an inline `int 3` — that is **not** in the engine's breakpoint table cannot be continued past. In the `breakpoint not in list` branch, the engine answers `DBG_EXCEPTION_NOT_HANDLED`, which re-raises the exception in the debuggee: the program's own SEH handler runs (or it becomes a second-chance/unhandled stop), and the debugger can't simply `continue` past the program's `DebugBreak()` the way Visual Studio does.

## Why it's wrong for a real `int 3`

For a single-byte `int 3` (0xCC) the CPU saves the exception context with RIP pointing **past** the instruction. So continuing only requires resuming the thread — no register fix-up is needed. VS consumes the exception (`DBG_CONTINUE`) and resumes at the next instruction.

`DBG_EXCEPTION_NOT_HANDLED` instead lets the exception propagate into the debuggee: with no SEH handler the process hits a second-chance/unhandled stop (or exits `0x80000003`); with one, the handler runs. Either way the debugger cannot continue past the program's own breakpoint.

## How I got here (two iterations)

1. **First attempt** answered `DBG_CONTINUE` for *every* stray breakpoint exception. That fixed `DebugBreak()` but regressed `RaiseException(STATUS_BREAKPOINT)`: the exception was consumed and the debuggee's `__except` handler no longer ran.

2. **Final version** distinguishes a real single-byte `int 3` from a programmatic raise by reading the byte at `ExceptionRecord.ExceptionAddress`:
   - `0xCC` (a real `int 3` the program executed) → `DBG_CONTINUE` (like VS);
   - otherwise (e.g. `RaiseException(STATUS_BREAKPOINT)`) → keep `DBG_EXCEPTION_NOT_HANDLED` so the debuggee's SEH still runs.

```cpp
unsigned char opcode = 0;
bool isInt3 = MemoryReadSafe(dbgProcessInformation.hProcess,
                             (LPVOID)exceptionAddress, &opcode, 1, 0) &&
              opcode == 0xCC;
DBGCode = isInt3 ? DBG_CONTINUE : DBG_EXCEPTION_NOT_HANDLED;
```

## Scope / impact

Only the `breakpoint not in list` branch changes. Debugger-set breakpoints, the system breakpoint, single-stepping, hardware/memory breakpoints and the AV/div-zero paths are untouched (they live in separate branches/switch cases).

## Verification

Windows x64, driven through a 21-case debugger test suite (aidbg):
- `DebugBreak()` — stops once, `continue` resumes past it, process exits cleanly (before: stop-loop + exit `0x80000003`).
- `__debugbreak()` — same.
- `DebugBreak()` inside `__try/__except(STATUS_BREAKPOINT)` — the handler is consumed by the debugger on `continue` (matches VS), process continues.
- `RaiseException(STATUS_BREAKPOINT)` + `__except` — SEH handler still runs (behavior unchanged from before the fix).
- All 21 cases pass, no regressions.

Related but distinct: step-over-int3 cleanup was already addressed in PR #32 / issue #33 (different DebugLoop branch). See also issue #36.
