### PR TITLE
Release breakpoint lock before the AV/GUARD_PAGE handler callback (fixes MemoryReadSafe deadlock)

### DIFF
--- a/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
+++ b/TitanEngine/TitanEngine.Debugger.DebugLoop.cpp
@@ -1193,6 +1193,14 @@ __declspec(dllexport) void TITCALL DebugLoop()
                 // Debuggee generated the GUARD_PAGE or ACCESS_VIOLATION exception
                 if(DBGCode == DBG_EXCEPTION_NOT_HANDLED)
                 {
+                    // The AV/GUARD_PAGE handler may block until the debugger resumes
+                    // the target (debuggers pause on the second-chance exception).
+                    // It is called from inside the memory-breakpoint transaction lock
+                    // above, so release it first or any MemoryReadSafe the debugger
+                    // runs while paused (BreakPointPostReadFilter takes this same
+                    // lock) deadlocks on memory inspection after a crash stop.
+                    breakpointLock.unlock();
+
                     if(isAccessViolation)
                     {
                         if(DBGCustomHandler->chAccessViolation != NULL)


### PR DESCRIPTION
## Summary

`DebugLoop()` acquires `LockBreakPointBuffer` at the top of the `STATUS_GUARD_PAGE_VIOLATION` / `STATUS_ACCESS_VIOLATION` case and only releases it when that case block ends. For a debuggee-generated AV/GUARD_PAGE exception (no memory breakpoint involved), `DBGCode` stays `DBG_EXCEPTION_NOT_HANDLED` and `chAccessViolation` / `chPageGuard` is invoked from **inside** that lock scope. A debugger that pauses in that callback (second-chance exception stop) leaves the lock held; the next `MemoryReadSafe` from the debugger then blocks forever in `BreakPointPostReadFilter`, which takes the same lock.

This mirrors the existing pattern already used for the memory-breakpoint callback (which calls `breakpointLock.unlock()` before entering the user callback).

## Repro / evidence

- Issue: #39 (with before/after run comparison and a linked downstream repro test)
- Reproduce: debug a process raising a second-chance `STATUS_ACCESS_VIOLATION`; pause in the AV handler, then call `MemoryReadSafe` from the debugger -> deadlock. `bt` (which does not use `MemoryReadSafe`) still works.

## Change

Release `breakpointLock` before invoking the AV/GUARD_PAGE handler.

Fixes #39
